### PR TITLE
Update ansible.yml r/sudo/become

### DIFF
--- a/ansible.yml
+++ b/ansible.yml
@@ -3,7 +3,9 @@
 
 - hosts: all
   remote_user: vagrant
-  sudo: yes
+  become: true
+  become_user: root
+  become_method: sudo
   tasks:
     - name: make sure node ppa is available
       apt_repository: repo='ppa:chris-lea/node.js'


### PR DESCRIPTION
Following the [ansible docs](http://docs.ansible.com/ansible/become.html), this removes a deprecation message when I run vagrant up or vagrant provision.
